### PR TITLE
Add English to Chinese translator with speech and history

### DIFF
--- a/site13/index.html
+++ b/site13/index.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="zh-TW">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>英文翻譯助手</title>
+    <style>
+        body {
+            font-family: "Microsoft JhengHei", sans-serif;
+            margin: 2em;
+            background: #f5f5f5;
+        }
+        #history {
+            margin-top: 2em;
+            padding: 0;
+            list-style: none;
+        }
+        #history li {
+            background: #fff;
+            margin-bottom: 8px;
+            padding: 8px;
+            border-radius: 4px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        }
+        #result {
+            margin-top: 1em;
+            font-size: 1.2em;
+        }
+    </style>
+</head>
+<body>
+    <h1>英文翻譯助手</h1>
+    <input id="wordInput" type="text" placeholder="請輸入英文單字">
+    <button id="translateBtn">翻譯</button>
+    <div id="result"></div>
+    <h2>搜尋紀錄</h2>
+    <ul id="history"></ul>
+
+<script>
+const input = document.getElementById('wordInput');
+const btn = document.getElementById('translateBtn');
+const resultDiv = document.getElementById('result');
+const historyList = document.getElementById('history');
+
+btn.addEventListener('click', translateWord);
+input.addEventListener('keypress', e => { if (e.key === 'Enter') translateWord(); });
+
+function loadHistory() {
+    const records = JSON.parse(localStorage.getItem('translateHistory') || '[]');
+    historyList.innerHTML = '';
+    records.forEach(r => {
+        const li = document.createElement('li');
+        li.textContent = `${r.word} → ${r.translation}`;
+        historyList.appendChild(li);
+    });
+}
+
+function saveHistory(word, translation) {
+    const records = JSON.parse(localStorage.getItem('translateHistory') || '[]');
+    records.unshift({word, translation});
+    localStorage.setItem('translateHistory', JSON.stringify(records));
+}
+
+function translateWord() {
+    const word = input.value.trim();
+    if (!word) return;
+    const url = `https://translate.googleapis.com/translate_a/single?client=gtx&sl=en&tl=zh-TW&dt=t&q=${encodeURIComponent(word)}`;
+    fetch(url)
+        .then(res => res.json())
+        .then(data => {
+            const translation = data[0][0][0];
+            resultDiv.innerHTML = `${translation} <button id="speakBtn">🔊</button>`;
+            document.getElementById('speakBtn').addEventListener('click', () => playAudio(translation));
+            playAudio(translation);
+            saveHistory(word, translation);
+            loadHistory();
+        })
+        .catch(err => {
+            console.error(err);
+            resultDiv.textContent = '翻譯失敗，請稍後再試';
+        });
+}
+
+function playAudio(text) {
+    const audio = new Audio(`https://translate.google.com/translate_tts?ie=UTF-8&q=${encodeURIComponent(text)}&tl=zh-TW&client=tw-ob`);
+    audio.play();
+}
+
+loadHistory();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a standalone translator page with input box and result area
- fetch Google Translate results and play Chinese speech
- store and show previous translations using local storage

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c07e52fb68832e9bb538aff22d58f3